### PR TITLE
[POA-4365] Add demo run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -96,5 +96,6 @@ echo
 sudo POSTMAN_API_KEY="$POSTMAN_API_KEY" \
   postman-insights-agent apidump \
   --project "$SERVICE_ID" \
+  --filter "port ${APP_PORT_HOST}" \
   --repro-mode
 


### PR DESCRIPTION

This PR introduces a `run.sh` script that automates bringing up a complete Insights demo environment locally.

#### What it does
* Runs the Demo Dogs service container on a configurable port (default: `8000`)
* Performs a health check to ensure the service is ready before continuing
* Starts a load generator container to produce traffic against the service
* Launches the Postman Insights Agent in repro mode, streaming logs in the foreground
* Validates prerequisites and environment variables (`SERVICE_ID`, `POSTMAN_API_KEY`)
* Provides clear, colorized terminal output so users know exactly what’s happening
* Cleans up containers automatically on exit (`Ctrl+C`) and ends with a success message
